### PR TITLE
Prepare Stage — Data Cleaning & Reference/Production Split

### DIFF
--- a/configs/params.yaml
+++ b/configs/params.yaml
@@ -1,28 +1,80 @@
 # configs/params.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# Central configuration file — NO hardcoded values anywhere in source code.
+# All pipeline scripts read exclusively from this file.
+# ─────────────────────────────────────────────────────────────────────────────
 
+# ── Paths ────────────────────────────────────────────────────────────────────
 data:
-  raw_path: data/raw/WA_Fn-UseC_-Telco-Customer-Churn.csv
-  processed_path: data/processed/cleaned.csv
-  train_path: data/splits/train.csv
-  test_path: data/splits/test.csv
-  reference_path: data/splits/reference.csv
-  production_path: data/splits/production.csv
-  target_column: Churn
-  test_size: 0.2
-  random_state: 42
-  reference_ratio: 0.7   # first 70% = reference for drift
+  raw_path:                    data/raw/WA_Fn-UseC_-Telco-Customer-Churn.csv
 
-preprocessing:
-  pipeline_path: data/processed/preprocessing_pipeline.pkl
-  numeric_features:
-    - tenure
-    - MonthlyCharges
-    - TotalCharges
-  categorical_features:
-    - gender
-    - Partner
-    - Dependents
-    - PhoneService
+  # Stage 1 (prepare.py) outputs — cleaned, split, NO features yet
+  cleaned_reference_path:      data/splits/cleaned_reference.csv
+  cleaned_production_path:     data/splits/cleaned_production.csv
+
+  # Stage 2 (featurize.py) outputs — row-level + stat features applied
+  reference_path:              data/splits/reference.csv
+  production_path:             data/splits/production.csv
+
+  # Stage 4 (preprocess.py) outputs — encoded, scaled, SMOTE'd
+  train_path:                  data/splits/train.csv
+  test_path:                   data/splits/test.csv
+  production_processed_path:   data/splits/production_processed.csv
+
+  pipeline_path:               data/processed/preprocessing_pipeline.pkl
+  stats_path:                  data/processed/reference_stats.json  # reference-only statistics
+  target_column:               Churn
+
+# ── Cleaning ─────────────────────────────────────────────────────────────────
+cleaning:
+  drop_columns:
+    - customerID
+  totalcharges_fix_col:   tenure          # set TotalCharges = 0 where this col == 0
+  internet_service_cols:                  # consolidate "No internet service" → "No"
+    - OnlineSecurity
+    - OnlineBackup
+    - DeviceProtection
+    - TechSupport
+    - StreamingTV
+    - StreamingMovies
+  phone_service_cols:                     # consolidate "No phone service" → "No"
+    - MultipleLines
+
+# ── Feature Engineering (row-level — applied in featurize.py) ────────────────
+feature_engineering:
+  service_cols:                           # used to compute NumServices
+    - OnlineSecurity
+    - OnlineBackup
+    - DeviceProtection
+    - TechSupport
+    - StreamingTV
+    - StreamingMovies
+    - MultipleLines
+  new_customer_tenure_threshold: 12       # tenure ≤ this value → IsNewCustomer = 1
+  risky_contract_value: Month-to-month   # contract type used for IsRiskySegment flag
+
+# ── Reference / Production Split ─────────────────────────────────────────────
+split:
+  reference_ratio: 0.70                  # first 70 % of rows → reference set
+  test_size:        0.20                 # 20 % of reference → test set
+  random_state:     42
+
+# ── Statistical Feature Engineering (reference-only statistics) ───────────────
+# All statistics and imputation values are computed ONLY from the reference set
+# and saved to stats_path. They are applied identically to train, test, and
+# production sets to guarantee consistent feature definitions with no leakage.
+stat_features:
+  high_value_quantile: 0.75             # MonthlyCharges percentile → IsHighValueCustomer
+
+# ── Encoding ─────────────────────────────────────────────────────────────────
+encoding:
+  binary_columns:
+  - gender
+  - Partner
+  - Dependents
+  - PhoneService
+  - PaperlessBilling
+  ohe_columns:                           # one-hot encoded; fit on train, applied to all
     - MultipleLines
     - InternetService
     - OnlineSecurity
@@ -32,21 +84,41 @@ preprocessing:
     - StreamingTV
     - StreamingMovies
     - Contract
-    - PaperlessBilling
     - PaymentMethod
-  drop_columns:
-    - customerID
-  imputer_strategy: median
-  scaler: standard
-  use_smote: true
-
-monitoring:
-  drift_threshold: 0.2       # >20% of features drifted = warning
-  drift_report_path: monitoring/evidently_reports/drift_report.html
-  baseline_report_path: monitoring/evidently_reports/baseline_report.html
-  noise_scale: 3.0           # multiplier for injected noise
-  noisy_features:
+  
+validation:
+  engineered_features:
+    - AvgMonthlyCharges
+    - ChargeDeviation
+    - TotalCharges_log
+    - NumServices
+    - IsNewCustomer
+    - IsRiskySegment
+    - IsHighValueCustomer
+# ── Preprocessing (encoding + scaling + imputation + SMOTE) ──────────────────
+preprocessing:
+  scaler:           standard             # "standard" = StandardScaler
+  numeric_features:                      # columns passed to the scaler (includes all engineered)
     - tenure
     - MonthlyCharges
     - TotalCharges
-  prometheus_port: 8001
+    - AvgMonthlyCharges
+    - ChargeDeviation
+    - TotalCharges_log
+    - NumServices
+    - IsHighValueCustomer
+  imputer_strategy: median               # sklearn fallback; TotalCharges NaN filled from reference median
+  use_smote:        true
+  smote_k_neighbors: 5
+
+# ── Monitoring ────────────────────────────────────────────────────────────────
+monitoring:
+  drift_threshold:      0.20            # alert if > 20 % of features drift
+  noise_scale:          3.0             # σ multiplier for Gaussian drift injection
+  noisy_features:                       # features to perturb in drift report
+    - tenure
+    - MonthlyCharges
+    - TotalCharges
+  baseline_report_path: monitoring/evidently_reports/baseline_report.html
+  drift_report_path:    monitoring/evidently_reports/drift_report.html
+  prometheus_port:      8001

--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,26 @@
+schema: '2.0'
+stages:
+  prepare:
+    cmd: python src/data/prepare.py
+    deps:
+    - path: configs/params.yaml
+      hash: md5
+      md5: 2a0e651f3dd094113af6224db65a72ad
+      size: 5878
+    - path: data/raw/WA_Fn-UseC_-Telco-Customer-Churn.csv
+      hash: md5
+      md5: 0f9de68e012bd3aed5fa7cdc9fc421af
+      size: 977501
+    - path: src/data/prepare.py
+      hash: md5
+      md5: d9ca852d602a19b9f5a54afae96fa273
+      size: 10024
+    outs:
+    - path: data/splits/cleaned_production.csv
+      hash: md5
+      md5: 0e16baf2fdc9200235ff872ea051de2a
+      size: 218059
+    - path: data/splits/cleaned_reference.csv
+      hash: md5
+      md5: d392cd040bfaffe4c0e13f8f1de8cd4c
+      size: 509550

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -1,0 +1,21 @@
+# dvc.yaml
+# ─────────────────────────────────────────────────────────────────────────────
+# DVC Pipeline — Telco Churn MLOps
+# Execution order: prepare → featurize → validate_schema → preprocess
+# Run full pipeline : dvc repro
+# View DAG          : dvc dag
+# ─────────────────────────────────────────────────────────────────────────────
+
+stages:
+
+  # ── Stage 1: Cleaning + Split (NO features) ───────────────────────────────
+  prepare:
+    cmd: python src/data/prepare.py
+    deps:
+      - src/data/prepare.py
+      - configs/params.yaml
+      - data/raw/WA_Fn-UseC_-Telco-Customer-Churn.csv
+    outs:
+      - data/splits/cleaned_reference.csv
+      - data/splits/cleaned_production.csv
+

--- a/src/data/prepare.py
+++ b/src/data/prepare.py
@@ -1,0 +1,210 @@
+# src/data/prepare.py
+"""
+Stage 1 — Cleaning, Target Encoding & Positional Split
+=======================================================
+
+Strict responsibility boundary: this stage performs ONLY data cleaning,
+target encoding, and the reference/production positional split.
+
+NO feature engineering of any kind is performed here — not row-level,
+not statistical. All feature engineering is exclusively owned by
+featurize.py (Stage 2).
+
+Execution order:
+
+  Step 1  clean()
+          — fix types, correct known invalid values, standardise
+            categorical labels, drop the identifier column.
+          NOTE: TotalCharges NaN rows that arise from pd.to_numeric
+            (non-tenure=0 whitespace entries) are left as NaN here.
+            They will be imputed by the sklearn pipeline in preprocess.py
+            using the reference-set median computed in featurize.py.
+
+  Step 2  encode_target()
+          — map Churn Yes → 1, No → 0 on the full dataset before the split
+            so both halves share the same integer encoding with no fitting.
+
+  Step 3  split_reference_production()
+          — deterministic positional 70/30 split.
+            The first 70 % of rows (older customers) become the reference
+            set used for training; the remaining 30 % become production,
+            simulating real-world temporal holdout.
+
+Leakage guarantees:
+  • No randomness in the split (purely positional).
+  • No aggregation across rows.
+  • No use of dataset statistics (mean, median, quantiles).
+  • No dependency on the reference/production relationship.
+
+Outputs:
+  data/splits/cleaned_reference.csv   (70 %) → input to featurize.py
+  data/splits/cleaned_production.csv  (30 %) → input to featurize.py
+"""
+
+import os
+
+import numpy as np
+import pandas as pd
+import yaml
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Config
+# ─────────────────────────────────────────────────────────────────────────────
+
+def load_params() -> dict:
+    with open("configs/params.yaml") as f:
+        return yaml.safe_load(f)
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 1: Cleaning
+# ─────────────────────────────────────────────────────────────────────────────
+
+def clean(df: pd.DataFrame, params: dict) -> pd.DataFrame:
+    """
+    Fix types, correct known invalid values, consolidate labels, drop ID.
+
+    All operations are row-level or schema-level; no dataset statistics are
+    used or computed.
+
+    TotalCharges NaN handling
+    ─────────────────────────
+    pd.to_numeric coerces whitespace-only strings to NaN. Rows where
+    tenure == 0 are factually corrected to 0.0 (customers never billed).
+    Any remaining NaN rows (data entry errors unrelated to tenure) are
+    intentionally left as NaN so the reference-median imputer in
+    preprocess.py handles them in a leakage-safe, reproducible way.
+    """
+
+    # 1a. TotalCharges stored as object due to whitespace entries → coerce
+    df["TotalCharges"] = pd.to_numeric(df["TotalCharges"], errors="coerce")
+
+    # 1b. tenure = 0 means customer was never billed → factual correction,
+    #     NOT statistical imputation.
+    fix_col = params["cleaning"]["totalcharges_fix_col"]
+    df.loc[df[fix_col] == 0, "TotalCharges"] = 0.0
+
+    # 1c. Consolidate redundant category labels to reduce OHE cardinality
+    for col in params["cleaning"]["internet_service_cols"]:
+        df[col] = df[col].replace("No internet service", "No")
+    for col in params["cleaning"]["phone_service_cols"]:
+        df[col] = df[col].replace("No phone service", "No")
+
+    # 1d. Drop customerID — unique per row, zero predictive signal
+    df.drop(columns=params["cleaning"]["drop_columns"], inplace=True)
+
+    return df
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 2: Target Encoding
+# ─────────────────────────────────────────────────────────────────────────────
+
+def encode_target(df: pd.DataFrame, target: str) -> pd.DataFrame:
+    """
+    Encode Churn: Yes → 1, No → 0.
+
+    Applied on the full dataset before the split so both halves share
+    the same integer encoding without any fitting step.
+    """
+    df[target] = df[target].map({"Yes": 1, "No": 0})
+    if df[target].isnull().any():
+        raise ValueError(
+            f"[prepare] '{target}' contains unexpected values after encoding. "
+            "Only 'Yes' and 'No' are valid in the raw data."
+        )
+    return df
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 3: Reference / Production Split
+# ─────────────────────────────────────────────────────────────────────────────
+
+def split_reference_production(
+    df: pd.DataFrame,
+    reference_ratio: float,
+    target: str,
+) -> tuple:
+    """
+    Positional split — first N rows become reference, the rest production.
+
+    Why positional (not random)?
+    The Telco dataset has no timestamp column, but row order approximates
+    customer acquisition order (older customers first). A positional split
+    therefore simulates the real-world pattern of training on historical
+    data and monitoring on newer arrivals, which is required for meaningful
+    drift simulation in the monitoring component.
+
+    Returns
+    -------
+    (reference_df, production_df)
+    """
+    split_idx = int(len(df) * reference_ratio)
+    reference_df = df.iloc[:split_idx].copy()
+    production_df = df.iloc[split_idx:].copy()
+
+    ref_churn = reference_df[target].mean()
+    prod_churn = production_df[target].mean()
+
+    print(f"[prepare] Split index : {split_idx} of {len(df)}")
+    print(f"[prepare] Reference   : {reference_df.shape} | churn rate: {ref_churn:.3f}")
+    print(f"[prepare] Production  : {production_df.shape} | churn rate: {prod_churn:.3f}")
+
+    gap = abs(ref_churn - prod_churn)
+    if gap > 0.05:
+        print(
+            f"[prepare] ⚠️  Churn rate gap {gap:.3f} — "
+            "natural concept drift between sets. EXPECTED for drift simulation."
+        )
+
+    return reference_df, production_df
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Main
+# ─────────────────────────────────────────────────────────────────────────────
+
+def prepare() -> None:
+    params = load_params()
+
+    raw_path = params["data"]["raw_path"]
+    cleaned_reference_path = params["data"]["cleaned_reference_path"]
+    cleaned_production_path = params["data"]["cleaned_production_path"]
+    target = params["data"]["target_column"]
+    reference_ratio = params["split"]["reference_ratio"]
+
+    for path in [cleaned_reference_path, cleaned_production_path]:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    # ── Step 1: Load & clean ──────────────────────────────────────────────────
+    print(f"[prepare] Loading raw data from: {raw_path}")
+    df = pd.read_csv(raw_path)
+    print(f"[prepare] Raw shape: {df.shape}")
+
+    df = clean(df, params)
+    nan_total = df.isnull().sum().sum()
+    print(f"[prepare] After cleaning : {df.shape} | NaN total: {nan_total}")
+    if nan_total > 0:
+        print(f"[prepare]   NaN breakdown:\n{df.isnull().sum()[df.isnull().sum() > 0]}")
+
+    # ── Step 2: Target encoding ───────────────────────────────────────────────
+    df = encode_target(df, target)
+    print(f"[prepare] Target encoded — {df[target].value_counts().to_dict()}")
+
+    # ── Step 3: Split ─────────────────────────────────────────────────────────
+    reference_df, production_df = split_reference_production(
+        df, reference_ratio, target
+    )
+
+    # ── Save cleaned splits (no features yet) ────────────────────────────────
+    reference_df.to_csv(cleaned_reference_path, index=False)
+    production_df.to_csv(cleaned_production_path, index=False)
+
+    print(f"[prepare] Cleaned reference  saved → {cleaned_reference_path}")
+    print(f"[prepare] Cleaned production saved → {cleaned_production_path}")
+    print("[prepare] DONE — feature engineering delegated to featurize.py")
+
+
+if __name__ == "__main__":
+    prepare()


### PR DESCRIPTION
## Closes
Issue #9 — Data Cleaning & Preparation Stage

## Summary
Implements deterministic data preparation for the Telco dataset including cleaning, target encoding, and reference/production split for downstream pipeline stages.

## Changes
- Added `src/data/prepare.py`
  - Cleaned `TotalCharges` and standardized categorical values
  - Dropped `customerID`
  - Encoded target (`Yes → 1`, `No → 0`)
  - Performed positional 70/30 split (reference/production)

## Pipeline
- Added `prepare` stage to `dvc.yaml`
- Outputs tracked via DVC:
  - `cleaned_reference.csv`
  - `cleaned_production.csv`

## Validation
- Deterministic output verified via `dvc repro`
- No feature engineering or leakage introduced
- Pipeline executes successfully end-to-end