### PR TITLE
Pipeline Schema Validation Stage

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -56,3 +56,27 @@ stages:
       hash: md5
       md5: 65b866c473672988eae5c3a349356271
       size: 797080
+  validate_schema:
+    cmd: python src/features/validate_schema.py
+    deps:
+    - path: configs/params.yaml
+      hash: md5
+      md5: 601b5681b84c567b0817ee94f55db6f8
+      size: 6002
+    - path: data/splits/production.csv
+      hash: md5
+      md5: b433fb89885399384869da7f29ba6005
+      size: 341907
+    - path: data/splits/reference.csv
+      hash: md5
+      md5: 65b866c473672988eae5c3a349356271
+      size: 797080
+    - path: src/features/validate_schema.py
+      hash: md5
+      md5: e7ea54064aa7206744c787640e9ddf4b
+      size: 3787
+    outs:
+    - path: data/splits/.schema_validated.flag
+      hash: md5
+      md5: d05b45e38c001045fb460d8218457228
+      size: 23

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -32,3 +32,14 @@ stages:
       - data/splits/reference.csv
       - data/splits/production.csv
       - data/processed/reference_stats.json
+
+  # ── Stage 3: Schema Validation (NO transformations) ──────────────────────
+  validate_schema:
+    cmd: python src/features/validate_schema.py
+    deps:
+      - src/features/validate_schema.py
+      - configs/params.yaml
+      - data/splits/reference.csv
+      - data/splits/production.csv
+    outs:
+      - data/splits/.schema_validated.flag

--- a/src/features/validate_schema.py
+++ b/src/features/validate_schema.py
@@ -1,0 +1,102 @@
+# src/features/validate_schema.py
+
+"""
+Stage 2 — Schema Validation & Handoff
+======================================
+
+Pure validation stage (NO transformations).
+
+Ensures:
+- engineered features exist
+- values are valid
+- consistency rules are respected
+
+Acts as a contract gate between:
+featurize.py and preprocess.py
+
+"""
+import pandas as pd
+import yaml
+import os
+
+def load_params():
+    with open("configs/params.yaml") as f:
+        return yaml.safe_load(f)
+
+
+def validate_features(df: pd.DataFrame, label: str, params: dict):
+
+    engineered = params["validation"]["engineered_features"]
+
+    threshold = params["feature_engineering"]["new_customer_tenure_threshold"]
+
+    # ─────────────────────────────
+    # 1. Missing columns
+    # ─────────────────────────────
+    missing = [c for c in engineered if c not in df.columns]
+    if missing:
+        raise ValueError(f"[validate_schema] {label} missing: {missing}")
+
+    # ─────────────────────────────
+    # 2. Null checks
+    # ─────────────────────────────
+    for col in engineered:
+        if df[col].isnull().any():
+            raise ValueError(f"[validate_schema] {label} nulls in {col}")
+
+    # ─────────────────────────────
+    # 3. Numeric validation
+    # ─────────────────────────────
+    if (df["NumServices"] < 0).any():
+        raise ValueError(f"[validate_schema] {label} NumServices < 0")
+
+    if (df["NumServices"] > 7).any():
+        raise ValueError(f"[validate_schema] {label} NumServices > 7")
+
+    if (df["AvgMonthlyCharges"] < 0).any():
+        raise ValueError(f"[validate_schema] {label} negative AvgMonthlyCharges")
+
+    if (df["TotalCharges_log"] < 0).any():
+        raise ValueError(f"[validate_schema] {label} negative log charges")
+
+    # ─────────────────────────────
+    # 4. Binary checks
+    # ─────────────────────────────
+    binary_cols = ["IsNewCustomer", "IsRiskySegment", "IsHighValueCustomer"]
+
+    for col in binary_cols:
+        if not df[col].dropna().isin([0, 1]).all():
+            raise ValueError(f"[validate_schema] {label} invalid binary {col}")
+
+    # ─────────────────────────────
+    # 5. Logical consistency
+    # ─────────────────────────────
+    if ((df["IsNewCustomer"] == 1) & (df["tenure"] > threshold)).any():
+        raise ValueError(f"[validate_schema] {label} invalid IsNewCustomer logic")
+
+    print(f"[validate_schema] {label} passed ✔")
+
+
+def validate_schema():
+    params = load_params()
+
+    ref = pd.read_csv(params["data"]["reference_path"])
+    prod = pd.read_csv(params["data"]["production_path"])
+
+    validate_features(ref, "reference", params)
+    validate_features(prod, "production", params)
+
+      # ─────────────────────────────
+    # CREATE FLAG FILE
+    # ─────────────────────────────
+    flag_path = "data/splits/.schema_validated.flag"
+    os.makedirs(os.path.dirname(flag_path), exist_ok=True)
+
+    with open(flag_path, "w") as f:
+        f.write("schema_validated=True\n")
+
+    print(f"[validate_schema] flag created → {flag_path}")
+    print("[validate_schema] schema validation complete ✔")
+
+if __name__ == "__main__":
+    validate_schema()


### PR DESCRIPTION

## Closes
Schema Validation Issue #56 

## Summary
Adds a **lightweight validation stage** to the pipeline acting as a gate between featurize and preprocess.  
Ensures engineered features are correct before entering the preprocessing stage.

## Changes
- Added `src/features/validate_schema.py`
  - Checks feature presence, nulls, ranges, binary values, and logic
  - Creates `.schema_validated.flag` on success
- Updated `dvc.yaml`
  - Added `validate` stage between featurize and preprocess

## Pipeline Role
featurize → **validate (this PR)** → preprocess

## Outputs
- `data/splits/.schema_validated.flag`

## Notes
- Not a full validation framework (no Pandera / Great Expectations)
- Designed as a fast pipeline guard to prevent silent failures